### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Pon-De-Ring-Pay2
+
+This repository contains a simple number guessing game implemented in HTML, CSS and JavaScript.
+
+## Running Locally
+Open `index.html` in a browser to play the game locally.
+
+## Deploying with GitHub Pages
+The included GitHub Actions workflow automatically deploys the contents of the repository to GitHub Pages whenever changes are pushed to the `main` branch.
+
+To enable Pages:
+1. Navigate to your repository's **Settings** tab.
+2. Select **Pages** from the sidebar.
+3. Under **Build and deployment**, choose **GitHub Actions** as the source.
+4. Save the settings.
+
+After the workflow completes successfully, the game will be available at:
+```
+https://<your-github-username>.github.io/Pon-De-Ring-Pay2/
+```


### PR DESCRIPTION
## Summary
- add workflow for GitHub Pages deployment
- document how to enable the workflow and deploy the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7ab085b88329aa234afcd0419eb6